### PR TITLE
Updates for bleak 0.19.0

### DIFF
--- a/microbot/__init__.py
+++ b/microbot/__init__.py
@@ -54,7 +54,7 @@ def parse_advertisement_data(
         data = {
             "address": device.address,  # MacOS uses UUIDs
             "local_name": advertisement_data.local_name,
-            "rssi": device.rssi,
+            "rssi": advertisement_data.rssi,
         }
 
     return MicroBotAdvertisement(device.address, data, device)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="PyMicroBot",
     packages=["microbot"],
-    install_requires=["bleak", "bleak-retry-connector>=1.4.0"],
+    install_requires=["bleak>=0.19.0", "bleak-retry-connector>=1.4.0"],
     version="0.0.8",
     description="A library to communicate with MicroBot",
     author="spycle",


### PR DESCRIPTION
The rssi value is now on AdvertisementData instead of the BLEDevice and will be removed from BLEDevice in bleak 0.20.0 or 0.21.0