### PR TITLE
Remove unused imports

### DIFF
--- a/microbot/__init__.py
+++ b/microbot/__init__.py
@@ -2,24 +2,19 @@
 from __future__ import annotations
 import logging
 import asyncio
-from typing import Optional, Any
-import async_timeout
-import bleak
-from bleak import BleakScanner, discover, BleakError
-from bleak.exc import BleakDBusError
+from typing import Any
+from bleak import BleakScanner
 from bleak_retry_connector import (
     BleakClientWithServiceCache,
-    BleakNotFoundError,
-    ble_device_has_changed,
     establish_connection,
 )
 from bleak.backends.device import BLEDevice
-from bleak.backends.service import BleakGATTCharacteristic, BleakGATTServiceCollection
+from bleak.backends.service import BleakGATTServiceCollection
 from bleak.backends.scanner import AdvertisementData
 from dataclasses import dataclass
 import random, string
 import binascii
-from binascii import hexlify, unhexlify
+from binascii import hexlify
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 CONNECT_LOCK = asyncio.Lock()


### PR DESCRIPTION
`bleak.discover` was removed in bleak v1. Unfortunately, this packages imports it without even using it. This required some workarounds for the Home Assistant PR to bump bleak which I'd like to remove. See https://github.com/home-assistant/core/pull/147742

This PR cleans up all the unused imports.